### PR TITLE
Mimc with the Miyaguchi-Preenel construct

### DIFF
--- a/examples/mimc_test.go
+++ b/examples/mimc_test.go
@@ -2,14 +2,14 @@ package examples
 
 import (
 	"fmt"
-	"github.com/consensys/gkr-mimc/circuit"
-	"github.com/consensys/gkr-mimc/common"
-	"github.com/consensys/gkr-mimc/gkr"
-	"github.com/consensys/gkr-mimc/hash"
 	"runtime"
 	"sync"
 	"testing"
 
+	"github.com/consensys/gkr-mimc/circuit"
+	"github.com/consensys/gkr-mimc/common"
+	"github.com/consensys/gkr-mimc/gkr"
+	"github.com/consensys/gkr-mimc/hash"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
@@ -29,7 +29,7 @@ func TestMimc(t *testing.T) {
 
 	// Initialize the circuit
 	mimcCircuit := CreateMimcCircuit()
-	// We test on the hashing of 0
+
 	// This checks the transition functions to be consistent
 	// With the actual hash function
 
@@ -46,16 +46,14 @@ func TestMimc(t *testing.T) {
 	outputs := assignment.Values[91]
 
 	// Sees if the output is consistent with the result of calling Mimc permutation
-	expectedHash := inputs[0][0]
+	newState := inputs[0][inputChunkSize/2]
+	block := inputs[0][0]
+	oldState := inputs[0][inputChunkSize/2]
 	// Our circuit expects the first addition to be made by the client
-	expectedHash.Sub(&expectedHash, &inputs[0][inputChunkSize/2])
-	hash.MimcPermutationInPlace(&expectedHash, inputs[0][inputChunkSize/2])
-	// And it does an extra addition by the key that is not done by the Mimc
-	// but is done by the Miyaguchi-Preenel constructs.
-	// Therefore we readd the key, to match the circuit result in the test
-	expectedHash.Add(&expectedHash, &inputs[0][inputChunkSize/2])
+	block.Sub(&block, &oldState)
+	hash.MimcPermutationInPlace(&newState, block)
 	// An error here indicate an error in the transition functions definition
-	assert.Equal(t, expectedHash.String(), outputs[0][0].String(), "Error on the state calculation")
+	assert.Equal(t, newState.String(), outputs[0][0].String(), "Error on the state calculation")
 
 	layer1 := assignment.Values[1]
 	gates := mimcCircuit.Layers[0].Gates

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/consensys/gkr-mimc
 go 1.16
 
 require (
-	github.com/consensys/gnark v0.4.1-0.20210608212302-1e69e2644e09 // indirect
-	github.com/consensys/gnark-crypto v0.4.1-0.20210608195447-78cc8bdb3077 // indirect
+	github.com/consensys/gnark v0.4.1-0.20210608212302-1e69e2644e09
+	github.com/consensys/gnark-crypto v0.4.1-0.20210608195447-78cc8bdb3077
 	github.com/pkg/profile v1.5.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHashes(t *testing.T) {
@@ -15,4 +16,12 @@ func TestHashes(t *testing.T) {
 	GMimcT4.Hash(inputs)
 	GMimcT8.Hash(inputs)
 	MimcHash(inputs)
+}
+
+func TestMimcCase(t *testing.T) {
+	var x, expectedY fr.Element
+	x.SetString("12")
+	y := MimcHash([]fr.Element{x})
+	expectedY.SetString("1808205620575546259657963589762746470347087906694759866517376279978241663265")
+	assert.Equal(t, y, expectedY, "Got %v", y.String())
 }

--- a/hash/mimc.go
+++ b/hash/mimc.go
@@ -18,19 +18,24 @@ func MimcHash(input []fr.Element) fr.Element {
 }
 
 // MimcUpdateInplace performs a state update using the Mimc permutation
+// Using Miyaguchi-Preenel
 func MimcUpdateInplace(state *fr.Element, block fr.Element) {
 	oldState := *state
 	MimcPermutationInPlace(state, block)
-	// TODO: readds the oldstate addition, when gnark moves to Miyaguchi-Preenel
 	state.Add(state, &oldState)
 	state.Add(state, &block)
 }
 
 // MimcPermutationInPlace applies the mimc permutation in place
+// In the Miyaguchi-Preenel construct, the state is used as the key of a cipher function
+// and the message to hash is set as the plaintext of the cipher
 func MimcPermutationInPlace(state *fr.Element, block fr.Element) {
 	for i := 0; i < MimcRounds; i++ {
-		state.Add(state, &block)
-		state.Add(state, &Arks[i])
-		SBoxInplace(state)
+		block.Add(&block, state)
+		block.Add(&block, &Arks[i])
+		SBoxInplace(&block)
 	}
+	// Re-add the state (key) to the block and put the result in the state
+	// to update the state
+	state.Add(state, &block)
 }

--- a/snark/hash/mimc.go
+++ b/snark/hash/mimc.go
@@ -10,18 +10,17 @@ import (
 func MimcHash(cs *frontend.ConstraintSystem, stream ...frontend.Variable) frontend.Variable {
 	state := cs.Constant(0)
 	for _, m := range stream {
-		oldState := state
+		newM := m
 		for i := 0; i < hash.MimcRounds; i++ {
-			// keys := cs.Constant(hash.Arks[i])
-			state = cs.Add(m, state, cs.Constant(hash.Arks[i]))
+			newM = cs.Add(newM, state)
+			newM = cs.Add(newM, cs.Constant(hash.Arks[i]))
 			// Raise to the power 7
-			tmp := cs.Mul(state, state) // ^2
-			tmp = cs.Mul(state, tmp)    // ^3
-			tmp = cs.Mul(tmp, tmp)      // ^6
-			state = cs.Mul(state, tmp)  // ^7
+			tmp := cs.Mul(newM, newM) // ^2
+			tmp = cs.Mul(newM, tmp)   // ^3
+			tmp = cs.Mul(tmp, tmp)    // ^6
+			newM = cs.Mul(newM, tmp)  // ^7
 		}
-		// Readd the oldState and the message as part of the Miyaguchi-Preenel construct
-		state = cs.Add(state, oldState, m)
+		state = cs.Add(state, newM, state, m)
 	}
 	return state
 }

--- a/snark/hash/mimc_test.go
+++ b/snark/hash/mimc_test.go
@@ -2,11 +2,12 @@ package hash
 
 import (
 	"fmt"
-	"github.com/consensys/gkr-mimc/common"
-	"github.com/consensys/gkr-mimc/hash"
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/consensys/gkr-mimc/common"
+	"github.com/consensys/gkr-mimc/hash"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"


### PR DESCRIPTION
* Update the Mimc hash function for both the snarks and the native execution
* Update the GKR linking in the tests